### PR TITLE
Disable plan variation in recreational mode

### DIFF
--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -110,7 +110,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				get_current_date());
 	}
 
-	if (prefs.display_variations)
+	if (prefs.display_variations && decoMode() != RECREATIONAL)
 		len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin %s"),
 				diveplan_duration(diveplan), "VARIATIONS<br></div>");
 	else

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -277,6 +277,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.problemsolvingtime->setValue(0);
 		ui.sacfactor->blockSignals(false);
 		ui.problemsolvingtime->blockSignals(false);
+		ui.display_variations->setDisabled(true);
 	}
 	else if (mode == VPMB) {
 		ui.label_gflow->setDisabled(true);
@@ -309,6 +310,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.problemsolvingtime->setDisabled(false);
 		ui.sacfactor->setValue(prefs.sacfactor / 100.0);
 		ui.problemsolvingtime->setValue(prefs.problemsolvingtime);
+		ui.display_variations->setDisabled(false);
 	}
 	else if (mode == BUEHLMANN) {
 		ui.label_gflow->setDisabled(false);
@@ -341,6 +343,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.problemsolvingtime->setDisabled(false);
 		ui.sacfactor->setValue(prefs.sacfactor / 100.0);
 		ui.problemsolvingtime->setValue(prefs.problemsolvingtime);
+		ui.display_variations->setDisabled(false);
 	}
 }
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -1036,7 +1036,7 @@ void DivePlannerPointsModel::computeVariations(struct diveplan *original_plan, s
 		return;
 	}
 
-	if(in_planner() && prefs.display_variations) {
+	if(in_planner() && prefs.display_variations && decoMode() != RECREATIONAL) {
 		int my_instance = ++instanceCounter;
 		cache_deco_state(&ds, &save);
 


### PR DESCRIPTION
Calculating variations when in recreational mode doesn't make sense, and can
prevent variations from being calculated when switching back to Buhlmann or
VPM-B modes.

Signed-off-by: Rick Walsh <rickmwalsh@gmail.com>